### PR TITLE
fix debug-only text labeled as info

### DIFF
--- a/apg_run_script/apg_run_script.pl
+++ b/apg_run_script/apg_run_script.pl
@@ -79,8 +79,9 @@ else{
         $debug = 255;
 }
 
-print "INFO\nINFO  ----> Welcome to the assign_validation_from_app script version $prog_version.\n",
-    "INFO  ---->\n" if $debug eq 255;
+print "DEBUG ---->\n",
+    "DEBUG ----> Welcome to DEBUG mode!\n",
+    "DEBUG ---->\n" if $debug eq 255;
 
 if (defined ($help)) {
 	print_usage();


### PR DESCRIPTION
If the -debug option is used, currently the script prints the name of an entirely different script with "INFO" rather than "DEBUG." This was a bit confusing.
