### PR TITLE
replace 'order' field with 'rule_number' field

### DIFF
--- a/apg_run_script/apg_run_script.pl
+++ b/apg_run_script/apg_run_script.pl
@@ -393,7 +393,7 @@ sub st_api_get_rule_uuid {
 		if ($l_device_vendor eq "Checkpoint") {
 			#code
 			if ($l_fw_rule->{binding}->{policy}->{name} eq $l_policy) {
-				if ($l_fw_rule->{order} eq $l_rule_num) {
+				if ($l_fw_rule->{rule_number} eq $l_rule_num) {
 					$l_rule_uid = $l_fw_rule->{uid};
 					$l_found_rule = 1;
 				}
@@ -402,7 +402,7 @@ sub st_api_get_rule_uuid {
 		elsif($l_device_vendor eq "Netscreen"){
 			if (($l_fw_rule->{binding}->{from_zone}->{name} eq $l_from_zone) and
 			    $l_fw_rule->{binding}->{to_zone}->{name} eq $l_to_zone) {
-				if ($l_fw_rule->{order} eq $l_rule_num) {
+				if ($l_fw_rule->{rule_number} eq $l_rule_num) {
 					$l_rule_uid = $l_fw_rule->{uid};
 					$l_found_rule = 1;
 				}
@@ -417,7 +417,7 @@ sub st_api_get_rule_uuid {
 			}
 			if (($l_fw_rule->{binding}->{from_zone}->{name} eq $l_from_zone) and
 			    $l_fw_rule->{binding}->{to_zone}->{name} eq $l_to_zone) {
-				if ($l_fw_rule->{order} eq $l_rule_num) {
+				if ($l_fw_rule->{rule_number} eq $l_rule_num) {
 					$l_rule_uid = $l_fw_rule->{uid};
 					$l_found_rule = 1;
 				}
@@ -432,7 +432,7 @@ sub st_api_get_rule_uuid {
 			elsif($l_acl_name =~ m/\wlobal/) {
 				#We have the Global ACL
 				if ($l_fw_rule->{binding}->{acl}->{global} eq "true"){
-					if ($l_fw_rule->{order} eq $l_rule_num) {
+					if ($l_fw_rule->{rule_number} eq $l_rule_num) {
 						$l_rule_uid = $l_fw_rule->{uid};
 						$l_found_rule = 1;
 					}
@@ -445,7 +445,7 @@ sub st_api_get_rule_uuid {
 				}
 				else{
 					if ($l_fw_rule->{binding}->{acl}->{interface}->{acl_name} eq $l_acl_name){
-						if ($l_fw_rule->{order} eq $l_rule_num) {
+						if ($l_fw_rule->{rule_number} eq $l_rule_num) {
 							$l_rule_uid = $l_fw_rule->{uid};
 							$l_found_rule = 1;
 						}


### PR DESCRIPTION
It seems the 'rule_number' field is the correct field to use to match on rule number rather than the 'order' field, at least for for Check Point devices. I am not certain that this is the case for Netscreen, Fortinet or Cisco devices, but I think it's safe to assume the database design is the same for all vendors. 

This fixes issue #9 as far as I can tell.
